### PR TITLE
Update validation limit to 50MB

### DIFF
--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,8 +1,8 @@
-// src/utils/validation.js (새 파일)
+// src/utils/validation.js
 export const validateFileContent = (content) => {
-  // 파일 크기 검증 (텍스트 기준 1MB)
-  if (content.length > 1024 * 1024) {
-    throw new Error('파일 내용이 너무 큽니다. (최대 1MB)');
+  // 파일 크기 검증 (텍스트 기준 50MB)
+  if (content.length > 50 * 1024 * 1024) {
+    throw new Error('파일 내용이 너무 큽니다. (최대 50MB)');
   }
 
   // 의심스러운 패턴 검사


### PR DESCRIPTION
## Summary
- raise file content validation limit to 50MB
- document new 50MB size limit in comments

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f3fe37e48330bb696c3171c29a2e