### PR TITLE
Fix notice update permission

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -219,7 +219,7 @@ service cloud.firestore {
       
       // 공지사항 업데이트 검증
       function isValidNoticeUpdate(data) {
-        let allowedFields = ['title', 'content', 'category', 'priority', 'isPinned', 'expiresAt', 'updatedAt', 'views'];
+        let allowedFields = ['title', 'content', 'category', 'priority', 'isPinned', 'expiresAt', 'updatedAt', 'updatedBy', 'views'];
         return data.diff(resource.data).affectedKeys().hasOnly(allowedFields);
       }
     }


### PR DESCRIPTION
## Summary
- allow `updatedBy` field for notice updates in Firestore rules

## Testing
- `npm run lint:check`
- `npm run test:ci` *(fails: TextEncoder not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6844065edb1083309ca49c7a437aba02